### PR TITLE
[discuss] One master per term

### DIFF
--- a/cluster/tla/consensus.tla
+++ b/cluster/tla/consensus.tla
@@ -51,6 +51,7 @@ VARIABLE currentClusterState
 VARIABLE lastAcceptedTerm
 VARIABLE lastAcceptedValue
 VARIABLE joinVotes
+VARIABLE allowElection
 VARIABLE electionWon
 VARIABLE publishPermitted
 VARIABLE publishVotes
@@ -62,6 +63,10 @@ ValidConfigs == SUBSET(Nodes) \ {{}}
 
 \* quorums correspond to majority of votes in a config
 IsQuorum(votes, config) == Cardinality(votes \cap config) * 2 > Cardinality(config)
+
+ElectionWon(n, votes) ==
+  /\ IsQuorum(votes, currentConfiguration[n])
+  /\ (lastAcceptedValue[n] /= Nil /\ lastAcceptedValue[n].type = Reconfigure) => IsQuorum(votes, lastAcceptedValue[n].val)
 
 \* checks whether two configurations only have intersecting quorums
 IntersectingQuorums(config1, config2) ==
@@ -77,6 +82,7 @@ Init == /\ messages = {}
         /\ lastAcceptedTerm = [n \in Nodes |-> Nil]
         /\ lastAcceptedValue = [n \in Nodes |-> Nil]
         /\ joinVotes = [n \in Nodes |-> {}]
+        /\ allowElection = [n \in Nodes |-> FALSE]
         /\ electionWon = [n \in Nodes |-> FALSE]
         /\ publishPermitted = [n \in Nodes |-> FALSE]
         /\ publishVotes = [n \in Nodes |-> {}]
@@ -94,6 +100,7 @@ HandleStartJoin(n, nm, t) ==
      IN
        /\ currentTerm' = [currentTerm EXCEPT ![n] = t]
        /\ publishPermitted' = [publishPermitted EXCEPT ![n] = TRUE]
+       /\ allowElection' = [allowElection EXCEPT ![n] = TRUE]
        /\ electionWon' = [electionWon EXCEPT ![n] = FALSE]
        /\ joinVotes' = [joinVotes EXCEPT ![n] = {}]
        /\ publishVotes' = [publishVotes EXCEPT ![n] = {}]
@@ -106,11 +113,12 @@ HandleStartJoin(n, nm, t) ==
 HandleJoinRequest(n, m) ==
   /\ m.method = Join
   /\ m.term = currentTerm[n]
+  /\ allowElection[n]
   /\ \/ /\ m.slot < firstUncommittedSlot[n]
      \/ /\ m.slot = firstUncommittedSlot[n]
         /\ (m.laTerm /= Nil => lastAcceptedTerm[n] /= Nil /\ m.laTerm <= lastAcceptedTerm[n])
   /\ joinVotes' = [joinVotes EXCEPT ![n] = @ \cup { m.source }]
-  /\ electionWon' = [electionWon EXCEPT ![n] = IsQuorum(joinVotes'[n], currentConfiguration[n])]
+  /\ electionWon' = [electionWon EXCEPT ![n] = ElectionWon(n, joinVotes'[n])]
   /\ IF electionWon'[n] /\ publishPermitted[n] /\ lastAcceptedTerm[n] /= Nil 
      THEN LET publishRequests == { [method  |-> PublishRequest,
                                     source  |-> n,
@@ -124,7 +132,7 @@ HandleJoinRequest(n, m) ==
      ELSE
        /\ UNCHANGED <<messages, publishPermitted>>
   /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, publishVotes,
-                 firstUncommittedSlot, lastAcceptedValue, lastAcceptedTerm>>
+                 firstUncommittedSlot, lastAcceptedValue, lastAcceptedTerm, allowElection>>
 
 \* client causes a cluster state change v
 ClientRequest(n, v) ==
@@ -142,13 +150,14 @@ ClientRequest(n, v) ==
      IN
        /\ publishPermitted' = [publishPermitted EXCEPT ![n] = FALSE]
        /\ messages' = messages \cup publishRequests
-       /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, electionWon,
+       /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, allowElection, electionWon,
                       firstUncommittedSlot, lastAcceptedValue, lastAcceptedTerm, joinVotes, publishVotes>>
 
 \* change the set of voters
 ChangeVoters(n, vs) ==
   /\ electionWon[n]
   /\ publishPermitted[n]
+  /\ IsQuorum(joinVotes[n], vs)
   /\ LET
        publishRequests == { [method  |-> PublishRequest,
                              source  |-> n,
@@ -159,7 +168,7 @@ ChangeVoters(n, vs) ==
      IN
        /\ publishPermitted' = [publishPermitted EXCEPT ![n] = FALSE]
        /\ messages' = messages \cup publishRequests
-       /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, electionWon,
+       /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, allowElection, electionWon,
                       firstUncommittedSlot, lastAcceptedValue, lastAcceptedTerm, joinVotes, publishVotes>>
 
 \* handle publish request m on node n
@@ -178,7 +187,7 @@ HandlePublishRequest(n, m) ==
                     slot    |-> m.slot]
      IN
        /\ messages' = messages \cup {response}
-       /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm,
+       /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, allowElection,
                       electionWon, firstUncommittedSlot, publishPermitted, joinVotes, publishVotes>>
 
 \* node n commits a change
@@ -200,7 +209,7 @@ HandlePublishResponse(n, m) ==
      ELSE
        UNCHANGED <<messages>>
   /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, electionWon,
-                   firstUncommittedSlot, lastAcceptedValue, lastAcceptedTerm,
+                   firstUncommittedSlot, lastAcceptedValue, lastAcceptedTerm, allowElection,
                    publishPermitted, joinVotes>>
 
 \* apply committed change to node n
@@ -208,6 +217,7 @@ HandleCommitRequest(n, m) ==
   /\ m.method = Commit
   /\ m.slot = firstUncommittedSlot[n]
   /\ m.term = lastAcceptedTerm[n]
+  /\ m.term >= currentTerm[n]
   /\ firstUncommittedSlot' = [firstUncommittedSlot EXCEPT ![n] = @ + 1]
   /\ lastAcceptedTerm' = [lastAcceptedTerm EXCEPT ![n] = Nil]
   /\ lastAcceptedValue' = [lastAcceptedValue EXCEPT ![n] = Nil]
@@ -215,14 +225,13 @@ HandleCommitRequest(n, m) ==
   /\ publishVotes' = [publishVotes EXCEPT ![n] = {}]
   /\ IF lastAcceptedValue[n].type = Reconfigure THEN
        /\ currentConfiguration' = [currentConfiguration EXCEPT ![n] = lastAcceptedValue[n].val]
-       /\ electionWon' = [electionWon EXCEPT ![n] = IsQuorum(joinVotes[n], currentConfiguration'[n])]
        /\ UNCHANGED <<currentClusterState>>
      ELSE
        /\ Assert(lastAcceptedValue[n].type = ApplyCSDiff, "unexpected type")
        /\ Assert(DOMAIN(lastAcceptedValue[n].val) = {currentClusterState[n]}, "diff mismatch")
        /\ currentClusterState' = [currentClusterState EXCEPT ![n] = lastAcceptedValue[n].val[@]] \* apply diff
-       /\ UNCHANGED <<currentConfiguration, electionWon>>
-  /\ UNCHANGED <<currentTerm, joinVotes, messages>>
+       /\ UNCHANGED <<currentConfiguration>>
+  /\ UNCHANGED <<currentTerm, joinVotes, messages, electionWon, allowElection>>
 
 \* node n captures current state and sends a catch up message
 SendCatchupResponse(n) ==
@@ -235,7 +244,7 @@ SendCatchupResponse(n) ==
        /\ messages' = messages \cup { catchupMessage }
        /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, 
                       lastAcceptedValue, electionWon, firstUncommittedSlot, publishPermitted,
-                      joinVotes, lastAcceptedTerm, publishVotes>>
+                      joinVotes, lastAcceptedTerm, publishVotes, allowElection>>
 
 \* node n handles a catchup message
 HandleCatchupResponse(n, m) ==
@@ -250,11 +259,12 @@ HandleCatchupResponse(n, m) ==
   /\ currentClusterState' = [currentClusterState EXCEPT ![n] = m.state]
   /\ joinVotes' = [joinVotes EXCEPT ![n] = {}]
   /\ publishVotes' = [publishVotes EXCEPT ![n] = {}]
-  /\ UNCHANGED <<currentTerm, messages>>
+  /\ UNCHANGED <<currentTerm, messages, allowElection>>
   
 
 \* crash/restart node n (loses ephemeral state)
 RestartNode(n) ==
+  /\ allowElection' = [allowElection EXCEPT ![n] = FALSE]
   /\ electionWon' = [electionWon EXCEPT ![n] = FALSE]
   /\ publishPermitted' = [publishPermitted EXCEPT ![n] = FALSE]
   /\ joinVotes' = [joinVotes EXCEPT ![n] = {}]
@@ -289,7 +299,6 @@ OneMasterPerTerm ==
     /\ electionWon[n1]
     /\ electionWon[n2]
     /\ currentTerm[n1] = currentTerm[n2]
-    /\ IntersectingQuorums(currentConfiguration[n1], currentConfiguration[n2])
     => n1 = n2
 
 LogMatching ==
@@ -302,7 +311,8 @@ SingleNodeInvariant ==
   \A n \in Nodes :
     /\ (lastAcceptedTerm[n] = Nil) = (lastAcceptedValue[n] = Nil)
     /\ lastAcceptedTerm[n] /= Nil => (lastAcceptedTerm[n] <= currentTerm[n])
-    /\ electionWon[n] = IsQuorum(joinVotes[n], currentConfiguration[n]) \* cached value is consistent
+    /\ (electionWon[n] => allowElection[n])
+    /\ electionWon[n] = ElectionWon(n, joinVotes[n]) \* cached value is consistent
     /\ electionWon[n] /\ publishPermitted[n] => lastAcceptedValue[n] = Nil
 
 LogMatchingMessages ==
@@ -312,6 +322,13 @@ LogMatchingMessages ==
     /\ m1.slot = m2.slot
     /\ m1.term = m2.term
     => m1.value = m2.value
+
+OneMasterPerTermMessages ==
+  \A m1, m2 \in messages:
+    /\ m1.method = PublishRequest
+    /\ m2.method = PublishRequest
+    /\ m1.term = m2.term
+    => m1.source = m2.source
 
 SafeCatchupMessages ==
   \A m1, m2 \in messages:

--- a/cluster/tla/consensus.tla
+++ b/cluster/tla/consensus.tla
@@ -131,6 +131,7 @@ HandleJoinRequest(n, m) ==
        /\ publishPermitted' = [publishPermitted EXCEPT ![n] = FALSE]
      ELSE
        /\ UNCHANGED <<messages, publishPermitted>>
+  /\ Assert(electionWon'[n] /\ \lnot electionWon[n] => publishPermitted[n], "publishing permitted when winning election")
   /\ UNCHANGED <<currentClusterState, currentConfiguration, currentTerm, publishVotes,
                  firstUncommittedSlot, lastAcceptedValue, lastAcceptedTerm, allowElection>>
 

--- a/cluster/tla/consensus.toolbox/consensus___model.launch
+++ b/cluster/tla/consensus.toolbox/consensus___model.launch
@@ -20,7 +20,7 @@
     <stringAttribute key="modelBehaviorNext" value="Next"/>
     <stringAttribute key="modelBehaviorSpec" value=""/>
     <intAttribute key="modelBehaviorSpecType" value="2"/>
-    <stringAttribute key="modelBehaviorVars" value="lastAcceptedTerm, currentClusterState, messages, firstUncommittedSlot, electionWon, publishVotes, currentTerm, currentConfiguration, joinVotes, publishPermitted, lastAcceptedValue"/>
+    <stringAttribute key="modelBehaviorVars" value="lastAcceptedTerm, currentClusterState, messages, firstUncommittedSlot, electionWon, publishVotes, allowElection, currentTerm, currentConfiguration, joinVotes, publishPermitted, lastAcceptedValue"/>
     <stringAttribute key="modelComments" value=""/>
     <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
     <listAttribute key="modelCorrectnessInvariants">
@@ -30,6 +30,7 @@
         <listEntry value="1SingleNodeInvariant"/>
         <listEntry value="1LogMatchingMessages"/>
         <listEntry value="1SafeCatchupMessages"/>
+        <listEntry value="1OneMasterPerTermMessages"/>
     </listAttribute>
     <listAttribute key="modelCorrectnessProperties"/>
     <stringAttribute key="modelExpressionEval" value=""/>


### PR DESCRIPTION
This change shows how the "one master per term" property from Raft can be reestablished in our model. I have not verified it, only model-checked.

The basic idea is to ensure that the leader already has enough (join) votes for the next prospective configuration when publishing said configuration. In most cases, this will already be the case if the leader eagerly collects join votes from the other nodes. In case where the property does not hold (and assuming a stable leader), the leader can try to reestablish this property by collecting votes in a higher term (simply by calling `HandleStartJoin` on itself and on the followers).

What changes to the model are required:
- When handling a configuration change (`ChangeVoters`), the leader checks if it has a quorum of joinVotes for that new configuration.
- When becoming leader (`HandleJoinRequest`) with a forced value, the node can only win the election if it has joinVotes both for the current configuration as well as the (forced) next configuration.

One of the nice side-effects of this change is that it ensures that `HandleCommitRequest` won't change `electionWon` (i.e. the node won't need to step down as leader or won't become leader when applying a commit with a configuration change). 

The change needs 2 smaller side-conditions for it to be correct:

1) After a node restart we need to make sure we don't use historic votes because some of the volatile state (such as joinVotes) is lost.
Raft does not have this issue because it starts nodes as follower, and when moving them to the candidate state (where they can collect votes), requires incrementing the term.
The problematic situation is as follows:
- send publish request with configuration change that's ok based on current joinVotes
- restart node, joinVotes get lost
- handle previously casted vote (message dup) and win election again for current config
- handle previously sent publish request to self with configuration change. The node might not have the joinVotes for that new configuration now, and might have to step down when it applies the commit for that config.

Same as Raft, we can ensure that we only start handling votes after a reboot once the term is incremented. I have implemented this with a boolean variable `allowElection` which is set to false on a reboot and reset to true when the term is incremented. `HandleJoinRequest` then requires for `allowElection` to be true in order to handle the join vote.

2) `HandleCommitRequest` can only allow commit requests which are not coming from a stale leader. This prevents a node from becoming leader because it got an `Commit` message from a now-defunct leader. While this is not strictly required for "one-master-per-term", it allows `electionWon` not to change in `HandleCommitRequest`.
