### PR TITLE
Only HandlePublishResponse when electionWon

### DIFF
--- a/ZenWithTerms/tla/ZenWithTerms.tla
+++ b/ZenWithTerms/tla/ZenWithTerms.tla
@@ -171,6 +171,7 @@ HandlePublishRequest(n, m) ==
 
 \* node n commits a change
 HandlePublishResponse(n, m) ==
+  /\ electionWon[n]
   /\ m.method = PublishResponse
   /\ m.term = currentTerm[n]
   /\ m.version = lastPublishedVersion[n]


### PR DESCRIPTION
HandlePublishResponse requires checking lastPublishedConfiguration, but it
might still happen on a non-leader if the leader was just rebooted. It's
conceptually preferable to avoid looking at lastPublishedConfiguration on
non-leaders: it saves reasoning about its behaviour across across reboots etc.