### PR TITLE
Generalize ClientRequest to take term and version as input

### DIFF
--- a/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
+++ b/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
@@ -19,7 +19,7 @@
     <stringAttribute key="modelBehaviorNext" value="Next"/>
     <stringAttribute key="modelBehaviorSpec" value=""/>
     <intAttribute key="modelBehaviorSpecType" value="2"/>
-    <stringAttribute key="modelBehaviorVars" value="lastAcceptedTerm, messages, lastPublishedConfiguration, electionWon, lastAcceptedInstance, publishVotes, allowElection, currentTerm, currentConfiguration, descendant, publishInstance, joinVotes, lastAcceptedConfiguration, lastAcceptedValue"/>
+    <stringAttribute key="modelBehaviorVars" value="lastAcceptedTerm, messages, lastPublishedConfiguration, lastPublishedVersion, electionWon, lastCommittedConfiguration, startedJoinSinceLastReboot, publishVotes, currentTerm, lastAcceptedVersion, descendant, joinVotes, lastAcceptedConfiguration, lastAcceptedValue"/>
     <stringAttribute key="modelComments" value=""/>
     <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
     <listAttribute key="modelCorrectnessInvariants">
@@ -44,7 +44,8 @@
     </listAttribute>
     <stringAttribute key="modelParameterContraint" value="StateConstraint"/>
     <listAttribute key="modelParameterDefinitions">
-        <listEntry value="Nat;;{0, 1, 2};0;0"/>
+        <listEntry value="Terms;;{0,1,2};0;0"/>
+        <listEntry value="Versions;;{0,1,2,3};0;0"/>
     </listAttribute>
     <stringAttribute key="modelParameterModelValues" value="{}"/>
     <stringAttribute key="modelParameterNewDefinitions" value=""/>


### PR DESCRIPTION
This aligns it with the implementation that allows to freely chose a term and version. I've run the model checker on this change and it completed in 16h 57min, which is longer than on the original model (4h 30min). I still think it's worth the change and, if desired, we can restrict state exploration using additional state constraints that restrict it back to the previous setting (using `lastPublishedVersion[n] <= lastAcceptedVersion[n] + 1`).