### PR TITLE
Invariant linking votes to committed configuration

### DIFF
--- a/ZenWithTerms/tla/ZenWithTerms.tla
+++ b/ZenWithTerms/tla/ZenWithTerms.tla
@@ -171,6 +171,7 @@ HandlePublishRequest(n, m) ==
 
 \* node n commits a change
 HandlePublishResponse(n, m) ==
+  /\ electionWon[n]
   /\ m.method = PublishResponse
   /\ m.term = currentTerm[n]
   /\ m.version = lastPublishedVersion[n]

--- a/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
+++ b/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
@@ -30,6 +30,7 @@
         <listEntry value="1CommittedValuesDescendantsFromInitialValue"/>
         <listEntry value="1DescendantRelationIsStrictlyOrdered"/>
         <listEntry value="1NewerOpsBasedOnOlderCommittedOps"/>
+        <listEntry value="1CommitHasQuorumVsPreviousCommittedConfiguration"/>
     </listAttribute>
     <listAttribute key="modelCorrectnessProperties"/>
     <stringAttribute key="modelExpressionEval" value=""/>


### PR DESCRIPTION
It seems reasonable that an update can be committed only when a quorum of responses has been received _for the configurations quoted in the update_, but this is not the case:

```
[ method |-> Join, source |-> n1, dest |-> n1, term |-> 1, laTerm |-> 0, laVersion |-> 0 ]
[ method |-> Join, source |-> n2, dest |-> n1, term |-> 1, laTerm |-> 0, laVersion |-> 0 ]
[ config |-> {n2}, method |-> PublishRequest, source |-> n1, dest |-> AllNodes, term |-> 1, version |-> 1, value |-> v1, commConf |-> {n1, n2, n3} ]
[ method |-> PublishResponse, source |-> n1, dest |-> n1, term |-> 1, version |-> 1 ]
[ method |-> PublishResponse, source |-> n2, dest |-> n1, term |-> 1, version |-> 1 ]
[ method |-> Commit, source |-> n1, dest |-> AllNodes, term |-> 1, version |-> 1 ]
[ config |-> {n2}, method |-> PublishRequest, source |-> n1, dest |-> AllNodes, term |-> 1, version |-> 2, value |-> v1, commConf |-> {n1, n2, n3} ]
[ method |-> PublishResponse, source |-> n2, dest |-> n1, term |-> 1, version |-> 2 ]
[ method |-> Commit, source |-> n1, dest |-> AllNodes, term |-> 1, version |-> 2 ]
```

Here the leader sends the first `Commit` but does not act on it until after sending the following `PublishRequest`, meaning that this `PublishRequest` contains an old `commConf` that is no longer relevant by the time this update is committed.

This change fixes this invariant by preventing the leader from handling a commit in between sending a `PublishRequest` and sending the corresponding `PublishResponse`.