### PR TITLE
Add P2b-like invariant

### DIFF
--- a/ZenWithTerms/tla/ZenWithTerms.tla
+++ b/ZenWithTerms/tla/ZenWithTerms.tla
@@ -309,6 +309,11 @@ CommitHasQuorumVsPreviousCommittedConfiguration ==
                                                                  /\ mprs.version = mprq.version
                       }}, mprq.commConf))
 
+P2bInvariant ==
+  \A mc \in messages: mc.method = Commit
+    => (\A mprq \in messages: mprq.method = PublishRequest
+            => (mprq.term > mc.term => mprq.version > mc.version))
+
 \* State-exploration limits
 StateConstraint ==
   /\ \A n \in Nodes: IF currentTerm[n] <= 1 THEN lastPublishedVersion[n] <= 2 ELSE lastPublishedVersion[n] <= 3

--- a/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
+++ b/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
@@ -31,6 +31,7 @@
         <listEntry value="1DescendantRelationIsStrictlyOrdered"/>
         <listEntry value="1NewerOpsBasedOnOlderCommittedOps"/>
         <listEntry value="1CommitHasQuorumVsPreviousCommittedConfiguration"/>
+        <listEntry value="1P2bInvariant"/>
     </listAttribute>
     <listAttribute key="modelCorrectnessProperties"/>
     <stringAttribute key="modelExpressionEval" value=""/>


### PR DESCRIPTION
Lamport's proof of the safety of Paxos hinges on the relationship between
commits and subsequent publications. Here a similar relationship holds.