### PR TITLE
Add comment on handling replication request with higher primary term

### DIFF
--- a/data/tla/replication.tla
+++ b/data/tla/replication.tla
@@ -559,7 +559,21 @@ MaybeMarkPC(incomingTerm, n, globalCP) ==
     MarkPC(tlog[n], globalCP)
   ELSE
     tlog[n]
+    
+(* 
+`^\bf Note on handling replication requests with higher primary terms^'
+If replica receives replication request with the primary term greater than its current primary term, 
+it means that new primary was promoted. The `^na\"ive^' handling of this case would be to forget all translog
+operations above global checkpoint, reset local checkpoint to global checkpoint and await replay 
+of operations above global checkpoint from the newly promoted primary.
+However, this approach does not work, because newly promoted primary might fail during resync process
+and if our replica is promoted to primary - it may miss operations above global checkpoint, effectively 
+loosing acknowledged writes.
 
+That's why we preserve existing entries in translog above global checkpoint but mark them as 
+pending confirmation. During operations replay, replica replaces it translog entry with the entry received 
+from the primary (which can be noop) and resets pending confirmation flag. 
+*)
 \* Replication request arrives on node n with message m
 HandleReplicationRequest(n, m) ==
    /\ m.request = TRUE

--- a/data/tla/replication.tla
+++ b/data/tla/replication.tla
@@ -562,16 +562,16 @@ MaybeMarkPC(incomingTerm, n, globalCP) ==
     
 (* 
 `^\bf Note on handling replication requests with higher primary terms^'
-If replica receives replication request with the primary term greater than its current primary term, 
+If a replica receives a replication request with a primary term greater than its current primary term, 
 it means that new primary was promoted. The `^na\"ive^' handling of this case would be to forget all translog
 operations above global checkpoint, reset local checkpoint to global checkpoint and await replay 
 of operations above global checkpoint from the newly promoted primary.
 However, this approach does not work, because newly promoted primary might fail during resync process
 and if our replica is promoted to primary - it may miss operations above global checkpoint, effectively 
-loosing acknowledged writes.
+losing acknowledged writes.
 
 That's why we preserve existing entries in translog above global checkpoint but mark them as 
-pending confirmation. During operations replay, replica replaces it translog entry with the entry received 
+pending confirmation. During operations replay, replica replaces its translog entry with the entry received 
 from the primary (which can be noop) and resets pending confirmation flag. 
 *)
 \* Replication request arrives on node n with message m


### PR DESCRIPTION
Currently, it's not immediately obvious why we need to have pending confirmation status of translog entries, because the first idea that comes to the mind of the reader is just to forget all translog entries above the global checkpoint and await these entries replay from the primary. 
This commit explicitly adds the comment, that pending confirmation status is needed to handle new primary failures.