### PR TITLE
 Quorum-based bootstrapping

### DIFF
--- a/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
+++ b/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
@@ -44,6 +44,7 @@
         <listEntry value="PublishResponse;;PublishResponse;1;0"/>
         <listEntry value="Values;;{v1, v2};1;1"/>
         <listEntry value="PublishRequest;;PublishRequest;1;0"/>
+        <listEntry value="NotNodes;;{x1, x2, x3};1;1"/>
     </listAttribute>
     <stringAttribute key="modelParameterContraint" value="StateConstraint"/>
     <listAttribute key="modelParameterDefinitions">

--- a/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
+++ b/ZenWithTerms/tla/ZenWithTerms.toolbox/ZenWithTerms___model.launch
@@ -44,7 +44,7 @@
         <listEntry value="PublishResponse;;PublishResponse;1;0"/>
         <listEntry value="Values;;{v1, v2};1;1"/>
         <listEntry value="PublishRequest;;PublishRequest;1;0"/>
-        <listEntry value="NotNodes;;{x1, x2, x3};1;1"/>
+        <listEntry value="NotNodes;;{x1};1;1"/>
     </listAttribute>
     <stringAttribute key="modelParameterContraint" value="StateConstraint"/>
     <listAttribute key="modelParameterDefinitions">


### PR DESCRIPTION
Today we model bootstrapping by defining the initial configuration on one or
more nodes. The initial configuration comprises a set of node IDs, generated by
each node when it first starts. In practice this means that a node must find
all the other nodes before it can bootstrap, so it knows their IDs.

In fact we want to be able to bootstrap a node once it has found a mere quorum
of the other nodes, in case some of the other nodes fail to start. We do this
by creating an initial configuration of an appropriate size, filling in any
unknown entries with ids that cannot ever belong to a node. Since the extra
entries do not belong to nodes, they never correspond to any votes, ensuring
that the system does not diverge even though the initial configuration is not
wholly consistent across the cluster.