### PR TITLE
MetaData storage specification

### DIFF
--- a/Storage/tla/Storage.tla
+++ b/Storage/tla/Storage.tla
@@ -161,7 +161,7 @@ Next ==
     \/ (state = "writeManifest"     /\ WriteManifest)
     \/ (state = "deleteOldManifest" /\ DeleteOldManifest)
     \/ (state = "deleteOldMeta"     /\ DeleteOldMeta)
-    \/ (state = "deleteNewManifest" /\ DeleteNewManifestEasy) \* try DeleteNewBuggy and DeleteNewHard
+    \/ (state = "deleteNewManifest" /\ DeleteNewManifestEasy) \* try DeleteNewManifestBuggy and DeleteNewManifestHard
     \/ (state = "deleteNewMeta"     /\ DeleteNewMeta)
 --------------------------------------------------------------------------
 (*************************************************************************)

--- a/Storage/tla/Storage.tla
+++ b/Storage/tla/Storage.tla
@@ -1,7 +1,7 @@
 ------------------------------ MODULE Storage ------------------------------
 EXTENDS Integers, FiniteSets, TLC
 
-CONSTANTS MaxNumberOfSteps \* maximum number of execution steps of FSM
+CONSTANTS MaxNewMeta \* maximum number of execution steps of FSM
 
 VARIABLES
   metadata,      \* metaData[i] = 1 if metadata of generation i is present
@@ -9,7 +9,6 @@ VARIABLES
   newMeta,       \* generation of newly created metadata file
   newManifest,   \* generation of newly created manifest file
   state,         \* current state, describes what to do next
-  steps,         \* number of execution steps of state machine capped by MaxNumberOfSteps
   possibleStates \* set of generations of metadata that limits what can be read from disk
 
 --------------------------------------------------------------------------
@@ -151,7 +150,6 @@ Init ==
    /\ newMeta = -1 \* no latest metadata file
    /\ newManifest = -1 \* no latest manifest file
    /\ state = "writeMeta" \* we start with writing metadata file
-   /\ steps = 0 \* no steps are taken by FSM yet
    /\ possibleStates = {} \* no metadata can be read from disk
     
 Next == 
@@ -159,8 +157,7 @@ Next ==
        \/ (state = "deleteMeta"    /\ DeleteMeta)
        \/ (state = "writeManifest" /\ WriteManifest)
        \/ (state = "deleteOld"     /\ DeleteOld)
-       \/ (state = "deleteNew"     /\ DeleteNewEasy) \* try DeleteNewEasy and DeleteNewHard
-    /\ steps' = steps + 1
+       \/ (state = "deleteNew"     /\ DeleteNewBuggy) \* try DeleteNewEasy and DeleteNewHard
 
 --------------------------------------------------------------------------
 (*************************************************************************)

--- a/Storage/tla/Storage.tla
+++ b/Storage/tla/Storage.tla
@@ -1,7 +1,7 @@
 ------------------------------ MODULE Storage ------------------------------
 EXTENDS Integers, FiniteSets, TLC
 
-CONSTANTS MaxNewMeta \* maximum number of execution steps of FSM
+CONSTANTS MaxNewMeta \* maximum generation of newMeta to limit the state space
 
 VARIABLES
   metadata,      \* metaData[i] = 1 if metadata of generation i is present
@@ -157,7 +157,7 @@ Next ==
        \/ (state = "deleteMeta"    /\ DeleteMeta)
        \/ (state = "writeManifest" /\ WriteManifest)
        \/ (state = "deleteOld"     /\ DeleteOld)
-       \/ (state = "deleteNew"     /\ DeleteNewBuggy) \* try DeleteNewEasy and DeleteNewHard
+       \/ (state = "deleteNew"     /\ DeleteNewEasy) \* try DeleteNewBuggy and DeleteNewHard
 
 --------------------------------------------------------------------------
 (*************************************************************************)

--- a/Storage/tla/Storage.tla
+++ b/Storage/tla/Storage.tla
@@ -1,0 +1,186 @@
+------------------------------ MODULE Storage ------------------------------
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS MaxNumberOfSteps \* maximum number of execution steps of FSM
+
+VARIABLES
+  metadata,      \* metaData[i] = 1 if metadata of generation i is present
+  manifest,      \* manifest[j] is generation of metadata j-th manifest is referencing
+  newMeta,       \* generation of newly created metadata file
+  newManifest,   \* generation of newly created manifest file
+  state,         \* current state, describes what to do next
+  steps,         \* number of execution steps of state machine capped by MaxNumberOfSteps
+  possibleStates \* set of generations of metadata that limits what can be read from disk
+
+--------------------------------------------------------------------------
+(*************************************************************************)
+(* First we define some helper functions to work with files abstraction. *)
+(* Files is a function from file generation to some content.             *)
+(* If content is -1, it means that file does not exist.                  *)                                                 
+(*************************************************************************)
+
+(*************************************************************************)
+(* CurrentGeneration returns the maximum file generation. If there are   *)
+(* no files then -1 is returned.                                         *)                                              
+(*************************************************************************)
+CurrentGeneration(files) == 
+    IF \A gen \in DOMAIN files : files[gen] = -1 
+    THEN -1 ELSE
+    CHOOSE gen \in DOMAIN files : 
+        /\ files[gen] /= -1
+        /\ \A otherGen \in DOMAIN files : 
+            \/ files[otherGen] = -1 
+            \/ gen \geq otherGen 
+
+(*************************************************************************)
+(* DeleteFile removes file with generation delGen.                        *)
+(*************************************************************************)
+DeleteFile(files, delGen) == 
+    [gen \in DOMAIN files |-> IF gen = delGen THEN -1 ELSE files[gen]]
+
+(*************************************************************************)
+(* DeleteFilesExcept removes all files except keepGen.                 *)
+(*************************************************************************)
+DeleteFilesExcept(files, keepGen) ==
+    [gen \in DOMAIN files |-> IF gen = keepGen THEN files[gen] ELSE -1]
+
+(*************************************************************************)
+(* WriteFile creates new file with specified generation and content.     *)
+(*************************************************************************)
+WriteFile(files, gen, content) ==
+    [files EXCEPT ![gen] = content]    
+  
+--------------------------------------------------------------------------
+(*************************************************************************)
+(* Now we define functions to emulate writing metadata.                  *)
+(*************************************************************************)
+WriteMetaOk(gen) == 
+    /\ metadata' = WriteFile(metadata, gen, 1)
+    /\ state' = "writeManifest"
+
+WriteMetaFail(gen) == 
+    /\ metadata' = metadata
+    /\ state' = "deleteMeta"
+                
+WriteMetaDirty(gen) == 
+    /\ \/ metadata' = WriteFile(metadata, gen, 1)
+       \/ metadata' = metadata
+    /\ state' = "deleteMeta"
+
+DeleteMeta == 
+    /\ \/ metadata' = DeleteFile(metadata, newMeta) 
+       \/ metadata' = metadata
+    /\ state' = "writeMeta"
+    /\ UNCHANGED <<newMeta, newManifest, manifest, possibleStates>> 
+
+WriteMeta == 
+    LET gen == CurrentGeneration(metadata) + 1 IN 
+        /\ newMeta' = gen
+        /\ \/ WriteMetaOk(gen) 
+           \/ WriteMetaFail(gen) 
+           \/ WriteMetaDirty(gen)
+        /\ UNCHANGED <<newManifest, manifest, possibleStates>>
+
+--------------------------------------------------------------------------
+(*************************************************************************)
+(* Now we define functions to emulate writing manifest file.             *)
+(*************************************************************************)      
+WriteManifestOk(gen) == 
+    /\ manifest' = WriteFile(manifest, gen, newMeta)
+    /\ state' = "deleteOld"
+    /\ possibleStates' = {newMeta}
+
+WriteManifestFail(gen) == 
+    /\ manifest' = manifest
+    /\ state' = "deleteMeta"
+    /\ possibleStates' = possibleStates
+                
+WriteManifestDirty(gen) == 
+    /\ \/ manifest' = WriteFile(manifest, gen, newMeta)
+       \/ manifest' = manifest
+    /\ state' = "deleteNew"
+    /\ possibleStates' = possibleStates \union {newMeta}
+          
+WriteManifest == 
+    LET gen == CurrentGeneration(manifest) + 1 IN
+        /\ newManifest' = gen
+        /\ \/ WriteManifestOk(gen)
+           \/ WriteManifestFail(gen)
+           \/ WriteManifestDirty(gen)
+        /\ UNCHANGED <<newMeta, metadata>>
+
+DeleteOld == 
+    /\ \/ manifest' = DeleteFilesExcept(manifest, newManifest)
+       \/ manifest' = manifest
+    /\ \/ metadata' = DeleteFilesExcept(metadata, newMeta) 
+       \/ metadata' = metadata
+    /\ state' = "writeMeta"
+    /\ UNCHANGED <<newMeta, newManifest, possibleStates>> 
+
+--------------------------------------------------------------------------
+(*************************************************************************)
+(* Below are 3 versions of the same function, that is called when        *)
+(* manifest write was dirty. The buggy one was initially implemented and *)
+(* was caught by https://github.com/elastic/elasticsearch/issues/39077.  *)
+(* Pick one and use in Next function.                                    *)
+(* https://github.com/elastic/elasticsearch/pull/40519 implements        *)
+(* DeleteNewEasy.                                                        *)
+(*************************************************************************)    
+DeleteNewBuggy == 
+    /\ \/ manifest' = DeleteFile(manifest, newManifest)
+       \/ manifest' = manifest
+    /\ \/ metadata' = DeleteFile(metadata, newMeta)
+       \/ metadata' = metadata
+    /\ state' = "writeMeta"
+    /\ UNCHANGED <<newMeta, newManifest, possibleStates>>
+
+DeleteNewEasy == 
+    /\ \/ manifest' = DeleteFile(manifest, newManifest)
+       \/ manifest' = manifest
+    /\ state' = "writeMeta"
+    /\ UNCHANGED <<newMeta, newManifest, possibleStates, metadata>>
+    
+DeleteNewHard == 
+    /\ \/ /\ manifest' = DeleteFile(manifest, newManifest)
+          /\ \/ metadata' = DeleteFile(metadata, newMeta)
+             \/ metadata' = metadata
+       \/ /\ manifest' = manifest
+          /\ metadata' = metadata
+    /\ state' = "writeMeta"
+    /\ UNCHANGED <<newMeta, newManifest, possibleStates>>
+
+--------------------------------------------------------------------------
+(*************************************************************************)
+(* We can define Init and Next functions now.                            *)
+(*************************************************************************)   
+Init == 
+   /\ metadata = [x \in 0..MaxNumberOfSteps |-> -1] \* reserve enough space for metadata files
+   /\ manifest = [x \in 0..MaxNumberOfSteps |-> -1] \* reserve enough space for manifest files
+   /\ newMeta = -1 \* no latest metadata file
+   /\ newManifest = -1 \* no latest manifest file
+   /\ state = "writeMeta" \* we start with writing metadata file
+   /\ steps = 0 \* no steps are taken by FSM yet
+   /\ possibleStates = {} \* no metadata can be read from disk
+    
+Next == 
+    /\ \/ (state = "writeMeta"     /\ WriteMeta)
+       \/ (state = "deleteMeta"    /\ DeleteMeta)
+       \/ (state = "writeManifest" /\ WriteManifest)
+       \/ (state = "deleteOld"     /\ DeleteOld)
+       \/ (state = "deleteNew"     /\ DeleteNewBuggy) \* try DeleteNewEasy and DeleteNewHard
+    /\ steps' = steps + 1
+
+--------------------------------------------------------------------------
+(*************************************************************************)
+(* Our model has 2 invariants.                                           *)
+(*************************************************************************)
+MetadataFileReferencedByManifestExists ==
+    CurrentGeneration(manifest) /= -1 
+        => 
+    metadata[manifest[CurrentGeneration(manifest)]] /= -1
+    
+MetadataReferencedByManifestIsValid ==
+    CurrentGeneration(manifest) /= -1 
+        =>
+    \E meta \in possibleStates : meta = manifest[CurrentGeneration(manifest)]
+============

--- a/Storage/tla/Storage.toolbox/Storage___model.launch
+++ b/Storage/tla/Storage.toolbox/Storage___model.launch
@@ -20,7 +20,7 @@
     <stringAttribute key="modelBehaviorNext" value="Next"/>
     <stringAttribute key="modelBehaviorSpec" value=""/>
     <intAttribute key="modelBehaviorSpecType" value="2"/>
-    <stringAttribute key="modelBehaviorVars" value="state, metadata, newManifest, possibleStates, steps, newMeta, manifest"/>
+    <stringAttribute key="modelBehaviorVars" value="state, metadata, newManifest, possibleStates, newMeta, manifest"/>
     <stringAttribute key="modelComments" value=""/>
     <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
     <listAttribute key="modelCorrectnessInvariants">
@@ -29,11 +29,11 @@
     </listAttribute>
     <listAttribute key="modelCorrectnessProperties"/>
     <stringAttribute key="modelExpressionEval" value=""/>
-    <stringAttribute key="modelParameterActionConstraint" value="steps &lt; MaxNumberOfSteps"/>
+    <stringAttribute key="modelParameterActionConstraint" value=""/>
     <listAttribute key="modelParameterConstants">
-        <listEntry value="MaxNumberOfSteps;;10;0;0"/>
+        <listEntry value="MaxNewMeta;;5;0;0"/>
     </listAttribute>
-    <stringAttribute key="modelParameterContraint" value=""/>
+    <stringAttribute key="modelParameterContraint" value="newMeta &lt; MaxNewMeta"/>
     <listAttribute key="modelParameterDefinitions"/>
     <stringAttribute key="modelParameterModelValues" value="{}"/>
     <stringAttribute key="modelParameterNewDefinitions" value=""/>

--- a/Storage/tla/Storage.toolbox/Storage___model.launch
+++ b/Storage/tla/Storage.toolbox/Storage___model.launch
@@ -6,7 +6,7 @@
     <intAttribute key="dfidDepth" value="100"/>
     <booleanAttribute key="dfidMode" value="false"/>
     <intAttribute key="distributedFPSetCount" value="0"/>
-    <stringAttribute key="distributedNetworkInterface" value="10.8.8.15"/>
+    <stringAttribute key="distributedNetworkInterface" value="10.2.42.180"/>
     <intAttribute key="distributedNodesCount" value="1"/>
     <stringAttribute key="distributedTLC" value="off"/>
     <stringAttribute key="distributedTLCVMArgs" value=""/>
@@ -32,6 +32,7 @@
     <stringAttribute key="modelParameterActionConstraint" value=""/>
     <listAttribute key="modelParameterConstants">
         <listEntry value="MaxNewMeta;;5;0;0"/>
+        <listEntry value="MetaDataContent;;MetaDataContent;1;0"/>
     </listAttribute>
     <stringAttribute key="modelParameterContraint" value="newMeta &lt; MaxNewMeta"/>
     <listAttribute key="modelParameterDefinitions"/>

--- a/Storage/tla/Storage.toolbox/Storage___model.launch
+++ b/Storage/tla/Storage.toolbox/Storage___model.launch
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+    <stringAttribute key="TLCCmdLineParameters" value=""/>
+    <stringAttribute key="configurationName" value="model"/>
+    <booleanAttribute key="deferLiveness" value="false"/>
+    <intAttribute key="dfidDepth" value="100"/>
+    <booleanAttribute key="dfidMode" value="false"/>
+    <intAttribute key="distributedFPSetCount" value="0"/>
+    <stringAttribute key="distributedNetworkInterface" value="10.8.8.15"/>
+    <intAttribute key="distributedNodesCount" value="1"/>
+    <stringAttribute key="distributedTLC" value="off"/>
+    <stringAttribute key="distributedTLCVMArgs" value=""/>
+    <intAttribute key="fpBits" value="1"/>
+    <intAttribute key="fpIndex" value="0"/>
+    <booleanAttribute key="fpIndexRandom" value="true"/>
+    <intAttribute key="maxHeapSize" value="25"/>
+    <intAttribute key="maxSetSize" value="1000000"/>
+    <booleanAttribute key="mcMode" value="true"/>
+    <stringAttribute key="modelBehaviorInit" value="Init"/>
+    <stringAttribute key="modelBehaviorNext" value="Next"/>
+    <stringAttribute key="modelBehaviorSpec" value=""/>
+    <intAttribute key="modelBehaviorSpecType" value="2"/>
+    <stringAttribute key="modelBehaviorVars" value="state, metadata, newManifest, possibleStates, steps, newMeta, manifest"/>
+    <stringAttribute key="modelComments" value=""/>
+    <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+    <listAttribute key="modelCorrectnessInvariants">
+        <listEntry value="1MetadataFileReferencedByManifestExists"/>
+        <listEntry value="1MetadataReferencedByManifestIsValid"/>
+    </listAttribute>
+    <listAttribute key="modelCorrectnessProperties"/>
+    <stringAttribute key="modelExpressionEval" value=""/>
+    <stringAttribute key="modelParameterActionConstraint" value="steps &lt; MaxNumberOfSteps"/>
+    <listAttribute key="modelParameterConstants">
+        <listEntry value="MaxNumberOfSteps;;10;0;0"/>
+    </listAttribute>
+    <stringAttribute key="modelParameterContraint" value=""/>
+    <listAttribute key="modelParameterDefinitions"/>
+    <stringAttribute key="modelParameterModelValues" value="{}"/>
+    <stringAttribute key="modelParameterNewDefinitions" value=""/>
+    <intAttribute key="numberOfWorkers" value="6"/>
+    <booleanAttribute key="recover" value="false"/>
+    <stringAttribute key="result.mail.address" value=""/>
+    <intAttribute key="simuAril" value="-1"/>
+    <intAttribute key="simuDepth" value="100"/>
+    <intAttribute key="simuSeed" value="-1"/>
+    <stringAttribute key="specName" value="Storage"/>
+    <stringAttribute key="view" value=""/>
+    <booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>


### PR DESCRIPTION
This PR adds metadata storage specification to prove that the way our storage layer underlying Zen2 implementation works correctly.
This specification does no model multipath, only a single data path is modeled.